### PR TITLE
Use `AssemblyLoadContextProxy` instead of `Assembly.LoadFile`

### DIFF
--- a/Targeting-NetStandard2.0/README.md
+++ b/Targeting-NetStandard2.0/README.md
@@ -1,12 +1,21 @@
 ## Target netstandard2.0
 
-Some modules are built targeting netstandard2.0,
+Some modules are built targeting `netstandard2.0` (or `net462`),
 so that a single build can work on both .NET (PowerShell 7+) and .NET Framework (Windows PowerShell 5.1).
 Also, it's quite common for a module to depend on `Newtonsoft.Json`,
 and it happens a lot that a module starts to have assembly conflicts with PowerShell because it depends on a higher version of the `Newtonsoft.Json` assembly.
 
-The type `AssemblyLoadContext` is not available when targeting netstandard2.0,
-so we will show how to use `AppDomain.AssemblyResolve` and `Assembly.LoadFile` to work around this issue.
+The type `AssemblyLoadContext` is not available when targeting `netstandard2.0` or `net462`,
+but it's easy to wrap a few reflection API calls to create a custom `AssemblyLoadContext` and load an assembly into it from path
+when the module runs in the .NET (PowerShell 7+) environment.
+so, we will create the `AssemblyLoadContextProxy` type that encapsulate those reflection operations,
+and we will show how to use `AppDomain.AssemblyResolve` and `AssemblyLoadContextProxy` to work around this assembly conflict issue.
+
+> **NOTE:** Do not use `Assembly.LoadFile` for the dependency isolation purpose.</br>
+> This API does load an assembly to a separate `AssemblyLoadContext` instance, but assemblies loaded by
+> this API are discoverable by PowerShell's type resolution code (see code [here](https://github.com/PowerShell/PowerShell/blob/918bb8c952af1d461abfc98bc709a1d359168a1c/src/System.Management.Automation/utils/ClrFacade.cs#L56-L61)).
+> So, your module could run into the "_Type Identity_" issue when loading an assembly by `Assembly.LoadFile` while another module
+> loads a different version of the same assembly into the default `AssemblyLoadContext`.
 
 ### Two scenarios
 

--- a/Targeting-NetStandard2.0/scenario-1/Class1.cs
+++ b/Targeting-NetStandard2.0/scenario-1/Class1.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
@@ -23,9 +24,23 @@ namespace assembly.conflict
 
     public class Init : IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
-        private static string dependencyFolder = Path.Combine(
-            Path.GetDirectoryName(typeof(Init).Assembly.Location),
-            "Dependencies");
+        private static readonly Assembly s_self;
+        private static readonly string s_dependencyFolder;
+        private static readonly HashSet<string> s_dependencies;
+        private static readonly AssemblyLoadContextProxy s_proxy;
+
+        static Init()
+        {
+            s_self = typeof(Init).Assembly;
+            s_dependencyFolder = Path.Combine(Path.GetDirectoryName(s_self.Location), "Dependencies");
+            s_dependencies = new(StringComparer.Ordinal);
+            s_proxy = AssemblyLoadContextProxy.CreateLoadContext("platyPS-load-context");
+
+            foreach (string filePath in Directory.EnumerateFiles(s_dependencyFolder, "*.dll"))
+            {
+                s_dependencies.Add(AssemblyName.GetAssemblyName(filePath).FullName);
+            }
+        }
 
         public void OnImport()
         {
@@ -37,25 +52,69 @@ namespace assembly.conflict
             AppDomain.CurrentDomain.AssemblyResolve -= ResolvingHandler;
         }
 
+        private static bool IsAssemblyMatching(AssemblyName assemblyName, Assembly requestingAssembly)
+        {
+            // The requesting assembly is always available in .NET, but could be null in .NET Framework.
+            // - When the requesting assembly is available, we check whether the loading request came from this
+            //   module, so as to make sure we only act on the request from this module.
+            // - When the requesting assembly is not available, we just have to depend on the assembly name only.
+            return requestingAssembly is not null
+                ? requestingAssembly == s_self && s_dependencies.Contains(assemblyName.FullName)
+                : s_dependencies.Contains(assemblyName.FullName);
+        }
+
         internal static Assembly ResolvingHandler(object sender, ResolveEventArgs args)
         {
-            string name = args.Name;
-            if (name.Equals("Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed", StringComparison.OrdinalIgnoreCase))
+            var assemblyName = new AssemblyName(args.Name);
+            if (IsAssemblyMatching(assemblyName, args.RequestingAssembly))
             {
-                string fileName = name.Substring(0, name.IndexOf(',')) + ".dll";
-                string filePath = Path.Combine(dependencyFolder, fileName);
+                string fileName = assemblyName.Name + ".dll";
+                string filePath = Path.Combine(s_dependencyFolder, fileName);
 
                 if (File.Exists(filePath))
                 {
-                    // In .NET, the 'LoadFile' API uses an anonymous 'AssemblyLoadContext' instance to load the assembly file.
-                    // But it maintains a cache to guarantee that the same assembly instance is returned for the same assembly file path.
-                    // For details, see the .NET code at https://source.dot.net/#System.Private.CoreLib/Assembly.cs,239
                     Console.WriteLine($"<*** Fall in 'ResolvingHandler': Newtonsoft.Json, Version=13.0.0.0  -- Loaded! ***>");
-                    return Assembly.LoadFile(filePath);
+                    // - In .NET, load the assembly into the custom assembly load context.
+                    // - In .NET Framework, assembly conflict is not a problem, so we load the assembly
+                    //   by 'Assembly.LoadFrom', the same as what powershell.exe would do.
+                    return s_proxy is not null
+                        ? s_proxy.LoadFromAssemblyPath(filePath)
+                        : Assembly.LoadFrom(filePath);
                 }
             }
 
             return null;
+        }
+    }
+
+    internal class AssemblyLoadContextProxy
+    {
+        private readonly object _customContext;
+        private readonly MethodInfo _loadFromAssemblyPath;
+
+        private AssemblyLoadContextProxy(Type alc, string loadContextName)
+        {
+            var ctor = alc.GetConstructor(new[] { typeof(string), typeof(bool) });
+            _loadFromAssemblyPath = alc.GetMethod("LoadFromAssemblyPath", new[] { typeof(string) });
+            _customContext = ctor.Invoke(new object[] { loadContextName, false });
+        }
+
+        internal Assembly LoadFromAssemblyPath(string assemblyPath)
+        {
+            return (Assembly) _loadFromAssemblyPath.Invoke(_customContext, new[] { assemblyPath });
+        }
+
+        internal static AssemblyLoadContextProxy CreateLoadContext(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var alc = typeof(object).Assembly.GetType("System.Runtime.Loader.AssemblyLoadContext");
+            return alc is not null
+                ? new AssemblyLoadContextProxy(alc, name)
+                : null;
         }
     }
 }

--- a/Targeting-NetStandard2.0/scenario-1/README.md
+++ b/Targeting-NetStandard2.0/scenario-1/README.md
@@ -15,7 +15,7 @@ The module folder `conflict` will be deployed to `.\bin\conflict`.
 PowerShell 7.0.x loads the version `12.0.0.0` of `Newtonsoft.Json` upon startup.
 The `conflict` module depends on the version `13.0.0.0` of `Newtonsoft.Json`.
 
-By leveraging `AppDomain.AssemblyResolve` and `Assembly.LoadFile`,
+By leveraging `AppDomain.AssemblyResolve` and `AssemblyLoadContextProxy`,
 the `conflict` module can work as expected in PowerShell 7.0.x.
 
 ![screenshot](./images/screen.jpg)

--- a/Targeting-NetStandard2.0/scenario-1/conflict.csproj
+++ b/Targeting-NetStandard2.0/scenario-1/conflict.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>conflict</AssemblyName>
+    <LangVersion>10.0</LangVersion>
 
     <!-- Disable PDB generation -->
     <DebugSymbols>false</DebugSymbols>
@@ -13,6 +14,7 @@
 
     <!-- Deploy the produced assembly -->
     <PublishDir>bin\conflict</PublishDir>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Targeting-NetStandard2.0/scenario-2/README.md
+++ b/Targeting-NetStandard2.0/scenario-2/README.md
@@ -17,7 +17,7 @@ The module folder `conflict` will be deployed to `.\bin\conflict`.
 PowerShell 7.0.x loads the version `12.0.0.0` of `Newtonsoft.Json` upon startup.
 The `conflict` module depends on the version `13.0.0.0` of `Newtonsoft.Json`.
 
-By leveraging `AppDomain.AssemblyResolve` and `Assembly.LoadFile`,
+By leveraging `AppDomain.AssemblyResolve` and `AssemblyLoadContextProxy`,
 the `conflict` module can work as expected in PowerShell 7.0.x.
 
 ![screenshot](./images/screen.jpg)

--- a/Targeting-NetStandard2.0/scenario-2/conflict/conflict.csproj
+++ b/Targeting-NetStandard2.0/scenario-2/conflict/conflict.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>conflict</AssemblyName>
+    <LangVersion>10.0</LangVersion>
 
     <!-- Disable PDB generation -->
     <DebugSymbols>false</DebugSymbols>
@@ -13,6 +14,7 @@
 
     <!-- Deploy the produced assembly -->
     <PublishDir>..\bin\conflict</PublishDir>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Targeting-NetStandard2.0/scenario-2/resolver/Class1.cs
+++ b/Targeting-NetStandard2.0/scenario-2/resolver/Class1.cs
@@ -1,15 +1,28 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
 
 namespace assembly.resolver
-{
+{ 
     public class Init : IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
-        private static string dependencyFolder = Path.Combine(
-            Path.GetDirectoryName(typeof(Init).Assembly.Location),
-            "Dependencies");
+        private static readonly string s_dependencyFolder;
+        private static readonly HashSet<string> s_dependencies;
+        private static readonly AssemblyLoadContextProxy s_proxy;
+
+        static Init()
+        {
+            s_dependencyFolder = Path.Combine(Path.GetDirectoryName(typeof(Init).Assembly.Location), "Dependencies");
+            s_dependencies = new(StringComparer.Ordinal);
+            s_proxy = AssemblyLoadContextProxy.CreateLoadContext("platyPS-load-context");
+
+            foreach (string filePath in Directory.EnumerateFiles(s_dependencyFolder, "*.dll"))
+            {
+                s_dependencies.Add(AssemblyName.GetAssemblyName(filePath).FullName);
+            }
+        }
 
         public void OnImport()
         {
@@ -21,24 +34,70 @@ namespace assembly.resolver
             AppDomain.CurrentDomain.AssemblyResolve -= ResolvingHandler;
         }
 
+        private static bool IsAssemblyMatching(AssemblyName assemblyName, Assembly requestingAssembly)
+        {
+            // The requesting assembly is always available in .NET, but could be null in .NET Framework.
+            // - When the requesting assembly is available, we check whether the loading request came from this
+            //   module (the 'conflict' assembly in this case), so as to make sure we only act on the request
+            //   from this module.
+            // - When the requesting assembly is not available, we just have to depend on the assembly name only.
+            return requestingAssembly is not null
+                ? requestingAssembly.FullName.StartsWith("conflict,") && s_dependencies.Contains(assemblyName.FullName)
+                : s_dependencies.Contains(assemblyName.FullName);
+        }
+
         internal static Assembly ResolvingHandler(object sender, ResolveEventArgs args)
         {
-            string name = args.Name;
-            if (name.Equals("Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed", StringComparison.OrdinalIgnoreCase))
+            var assemblyName = new AssemblyName(args.Name);
+            if (IsAssemblyMatching(assemblyName, args.RequestingAssembly))
             {
-                Console.WriteLine($"<*** Fall in 'ResolvingHandler': Newtonsoft.Json, Version=13.0.0.0  -- Loaded! ***>");
+                string fileName = assemblyName.Name + ".dll";
+                string filePath = Path.Combine(s_dependencyFolder, fileName);
 
-                string path = Path.Combine(dependencyFolder, name.Split(',')[0]) + ".dll";
-                if (File.Exists(path))
+                if (File.Exists(filePath))
                 {
-                    // When running in .NET, the 'LoadFile' API uses an anonymous AssemblyLoadContext to load the assembly file.
-                    // But it maintains a cache to guarantee that the same assembly instance is returned for the same assembly file path.
-                    // For details, see the .NET code at https://source.dot.net/#System.Private.CoreLib/Assembly.cs,239
-                    return Assembly.LoadFile(path);
+                    Console.WriteLine($"<*** Fall in 'ResolvingHandler': Newtonsoft.Json, Version=13.0.0.0  -- Loaded! ***>");
+                    // - In .NET, load the assembly into the custom assembly load context.
+                    // - In .NET Framework, assembly conflict is not a problem, so we load the assembly
+                    //   by 'Assembly.LoadFrom', the same as what powershell.exe would do.
+                    return s_proxy is not null
+                        ? s_proxy.LoadFromAssemblyPath(filePath)
+                        : Assembly.LoadFrom(filePath);
                 }
             }
 
             return null;
+        }
+    }
+
+    internal class AssemblyLoadContextProxy
+    {
+        private readonly object _customContext;
+        private readonly MethodInfo _loadFromAssemblyPath;
+
+        private AssemblyLoadContextProxy(Type alc, string loadContextName)
+        {
+            var ctor = alc.GetConstructor(new[] { typeof(string), typeof(bool) });
+            _loadFromAssemblyPath = alc.GetMethod("LoadFromAssemblyPath", new[] { typeof(string) });
+            _customContext = ctor.Invoke(new object[] { loadContextName, false });
+        }
+
+        internal Assembly LoadFromAssemblyPath(string assemblyPath)
+        {
+            return (Assembly) _loadFromAssemblyPath.Invoke(_customContext, new[] { assemblyPath });
+        }
+
+        internal static AssemblyLoadContextProxy CreateLoadContext(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var alc = typeof(object).Assembly.GetType("System.Runtime.Loader.AssemblyLoadContext");
+            return alc is not null
+                ? new AssemblyLoadContextProxy(alc, name)
+                : null;
         }
     }
 }

--- a/Targeting-NetStandard2.0/scenario-2/resolver/Class1.cs
+++ b/Targeting-NetStandard2.0/scenario-2/resolver/Class1.cs
@@ -5,7 +5,7 @@ using System.Management.Automation;
 using System.Reflection;
 
 namespace assembly.resolver
-{ 
+{
     public class Init : IModuleAssemblyInitializer, IModuleAssemblyCleanup
     {
         private static readonly string s_dependencyFolder;

--- a/Targeting-NetStandard2.0/scenario-2/resolver/resolver.csproj
+++ b/Targeting-NetStandard2.0/scenario-2/resolver/resolver.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>resolver</AssemblyName>
+    <LangVersion>10.0</LangVersion>
 
     <!-- Disable PDB generation -->
     <DebugSymbols>false</DebugSymbols>
@@ -13,6 +14,7 @@
 
     <!-- Deploy the produced assembly -->
     <PublishDir>..\bin\resolver</PublishDir>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Use `AssemblyLoadContextProxy` instead of `Assembly.LoadFile`.

Do not use `Assembly.LoadFile` for the dependency isolation purpose.

This API does load an assembly to a separate `AssemblyLoadContext` instance, but assemblies loaded by this API are discoverable by PowerShell's type resolution code (see code [here](https://github.com/PowerShell/PowerShell/blob/918bb8c952af1d461abfc98bc709a1d359168a1c/src/System.Management.Automation/utils/ClrFacade.cs#L56-L61)).

So, your module could run into the "_Type Identity_" issue when loading an assembly by `Assembly.LoadFile` while another module loads a different version of the same assembly into the default `AssemblyLoadContext`.